### PR TITLE
Fix bucket verification

### DIFF
--- a/cassandra-cloud-backup.sh
+++ b/cassandra-cloud-backup.sh
@@ -243,7 +243,7 @@ function validate() {
       logerror "Please pass in the GCS Bucket to use with this script"
       exit 1
   else
-      if ! ${GSUTIL} ls -l ${GCS_BUCKET} | grep -q ${GCS_BUCKET} ; then
+      if ! ${GSUTIL} ls ${GCS_BUCKET} &> /dev/null; then
         logerror "Cannot access Google Cloud Storage bucket ${GCS_BUCKET} make sure" \
         " it exists"
         exit 1


### PR DESCRIPTION
If the bucket is empty the old check fails.  The `grep` however is not needed as if there is a problem with the `gsuilt ls` it exits with a non-zero exit status.