### PR TITLE
execute parse_yaml_inventory action=inventory

### DIFF
--- a/cassandra-cloud-backup.sh
+++ b/cassandra-cloud-backup.sh
@@ -421,6 +421,9 @@ function validate() {
           fi
       fi
     fi
+  else
+    # ${ACTION} = "inventory"
+    parse_yaml_inventory
   fi
 
   logverbose "ERROR_COUNT: ${ERROR_COUNT}"


### PR DESCRIPTION
The function `parse_yaml_inventory` did not run when action equals inventory. Because of that, the `incremental_backups` setting was not parsed and so the tool printed an erroneous message:

> Incremental Backups are not enabled for Cassandra

Now, `parse_yaml_inventory` runs whenever action equals inventory.